### PR TITLE
feat: Implement TabView as root navigation

### DIFF
--- a/NewsAppPortfolio/NewsAppPortfolioApp.swift
+++ b/NewsAppPortfolio/NewsAppPortfolioApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct NewsAppPortfolioApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
         }
     }
 }

--- a/NewsAppPortfolio/Views/MainTabView.swift
+++ b/NewsAppPortfolio/Views/MainTabView.swift
@@ -1,0 +1,36 @@
+//
+//  MainTabView.swift
+//  NewsAppPortfolio
+//
+//  Created by Rodrigo Cerqueira Reis on 11/08/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            ContentView()
+                .tabItem {
+                    Label("News", systemImage: "newspaper")
+                }
+            
+            Text("Favorites")
+                .tabItem {
+                    Label("Favorites", systemImage: "bookmark.fill")
+                }
+            
+            Text("Profile")
+                .tabItem {
+                    Label("Profile", systemImage: "person.circle.fill")
+                }
+        }
+    }
+}
+
+struct MainTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabView()
+    }
+}


### PR DESCRIPTION
### Description
This PR refactors the app's root view to a `TabView`, establishing a multi-screen navigation structure. This change lays the groundwork for future features like a dedicated search screen and saved articles.

### What was added:
- **`MainTabView`:** A new root view that contains the application's primary navigation.
- **Tab Bar:** A `UITabBar`-style component is now displayed at the bottom of the screen.
- **Initial Tabs:** The existing `ContentView` is now the "News" tab. Placeholder tabs for "Favorites" and "Profile" have also been added.

### How to test:
1. Run the application.
2. Verify that a tab bar is visible at the bottom of the screen.
3. Tap on the "Saved" and "Profile" tabs to see the placeholder text.
4. The "News" tab should display the original article list.