### PR TITLE
feat: Refactor search functionality into a dedicated view

### DIFF
--- a/NewsAppPortfolio/Views/ContentView.swift
+++ b/NewsAppPortfolio/Views/ContentView.swift
@@ -14,30 +14,16 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                
-                TextField("Search for articles...", text: $viewModel.searchQuery)
-                    .padding(8)
-                    .background(Color(.systemGray6))
-                    .cornerRadius(8)
-                    .padding(.horizontal)
-                    .onChange(of: viewModel.searchQuery) { newQuery in
-                        Task {
-                            try await Task.sleep(nanoseconds: 500_000_000)
-                            await viewModel.fetchArticles(for: newQuery)
-                        }
-                    }
-                
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 15) {
                         ForEach(NewsViewModel.categories, id: \.self) { category in
                             Button(action: {
                                 viewModel.selectedCategory = category
-                                viewModel.searchQuery = ""
                                 Task {
                                     await viewModel.fetchArticles()
                                 }
                             }) {
-                                Text(category)
+                                Text(category.capitalized)
                                     .font(.caption)
                                     .fontWeight(.bold)
                                     .padding(.vertical, 8)
@@ -55,7 +41,7 @@ struct ContentView: View {
                 Group {
                     switch viewModel.loadingState {
                     case .idle:
-                        Text("Selecione uma categoria para carregar as notícias")
+                        Text("Select a category to load news")
                     case .loading:
                         List {
                             ForEach(0..<5) { _ in
@@ -65,16 +51,12 @@ struct ContentView: View {
                         .listStyle(.plain)
                         .redacted(reason: .placeholder)
                     case .success:
-                        if viewModel.articles.isEmpty && !viewModel.searchQuery.isEmpty {
-                            EmptySearchView(message: "No results found for '\(viewModel.searchQuery)'.")
-                        } else {
-                            List(viewModel.articles) { article in
-                                ArticleRowView(article: article)
-                            }
-                            .listStyle(.plain)
-                            .refreshable {
-                                await viewModel.fetchArticles()
-                            }
+                        List(viewModel.articles) { article in
+                            ArticleRowView(article: article)
+                        }
+                        .listStyle(.plain)
+                        .refreshable {
+                            await viewModel.fetchArticles()
                         }
                     case .failed(let error):
                         VStack {

--- a/NewsAppPortfolio/Views/MainTabView.swift
+++ b/NewsAppPortfolio/Views/MainTabView.swift
@@ -16,6 +16,11 @@ struct MainTabView: View {
                     Label("News", systemImage: "newspaper")
                 }
             
+            SearchView()
+                .tabItem {
+                    Label("Search", systemImage: "magnifyingglass")
+                }
+            
             Text("Favorites")
                 .tabItem {
                     Label("Favorites", systemImage: "bookmark.fill")

--- a/NewsAppPortfolio/Views/SearchView.swift
+++ b/NewsAppPortfolio/Views/SearchView.swift
@@ -1,0 +1,74 @@
+//
+//  SearchView.swift
+//  NewsAppPortfolio
+//
+//  Created by Rodrigo Cerqueira Reis on 11/08/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct SearchView: View {
+    @StateObject private var viewModel = NewsViewModel()
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                TextField("Search for articles...", text: $viewModel.searchQuery)
+                    .padding(8)
+                    .background(Color(.systemGray6))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                    .onChange(of: viewModel.searchQuery) { newQuery in
+                        Task {
+                            try await Task.sleep(nanoseconds: 500_000_000)
+                            await viewModel.fetchArticles(for: newQuery)
+                        }
+                    }
+                
+                Group {
+                    switch viewModel.loadingState {
+                    case .idle:
+                        Text("Start typing to search.")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .foregroundColor(.secondary)
+                    case .loading:
+                        List {
+                            ForEach(0..<5) { _ in
+                                SkeletonArticleRowView()
+                            }
+                        }
+                        .listStyle(.plain)
+                        .redacted(reason: .placeholder)
+                    case .success:
+                        if viewModel.articles.isEmpty && !viewModel.searchQuery.isEmpty {
+                            EmptySearchView(message: "No results found for '\(viewModel.searchQuery)'.")
+                        } else {
+                            List(viewModel.articles) { article in
+                                ArticleRowView(article: article)
+                            }
+                            .listStyle(.plain)
+                            .refreshable {
+                                await viewModel.fetchArticles(for: viewModel.searchQuery)
+                            }
+                        }
+                    case .failed(let error):
+                        VStack {
+                            Text("Error loading news: \(viewModel.errorMessage ?? error.localizedDescription)")
+                                .foregroundColor(.red)
+                                .multilineTextAlignment(.center)
+                                .padding()
+                            Button("Try Again") {
+                                Task {
+                                    await viewModel.fetchArticles()
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Search")
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR refactors the search functionality by moving it to a dedicated `View`. This change centralizes the search logic and improves code organization, freeing up the `ContentView` to focus exclusively on displaying news by category.

### What was added / changed:
- **`SearchView`:** A new `View` that contains all the search interface and logic.
- **Refactored `ContentView`:** The `ContentView` was simplified and now only displays category news, without the search bar.
- **`MainTabView`:** The new `SearchView` was added as a dedicated tab in the navigation bar.

### How to test:
1. Navigate to the "Search" tab.
2. Type a search term and verify that the results are displayed.
3. Clear the search bar and verify that the "Start typing..." message appears.
4. Navigate to the "News" tab and verify that the list of category news loads correctly.
